### PR TITLE
Add missing sys/stat.h include

### DIFF
--- a/src/agiplay.cpp
+++ b/src/agiplay.cpp
@@ -32,7 +32,7 @@
 #include <QProgressDialog>
 #include <QBuffer>
 #include <QEventLoop>
-
+#include <sys/stat.h>
 
 #define NUM_CHANNELS    4
 #define WAVEFORM_SIZE   64


### PR DESCRIPTION
I ran into https://github.com/Deledrius/agistudio/issues/4 as well on Ubuntu 22.04 LTS. After adding `#include <sys/stat.h>` it builds fine for me.