### PR TITLE
Fix mac get existing directory

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -965,7 +965,9 @@ void OpenGameDir(QWidget *parent, bool newgame)
     QString title("Open game");
     if (newgame)
         title = "New game";
-    QString dir = QFileDialog::getExistingDirectory(parent, title);
+    QString dir = QFileDialog::getExistingDirectory(parent,
+                                                    title, QDir::homePath(),
+                                                    QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
     if (dir.isNull())
         return;
 

--- a/src/ui/mainmenu.ui
+++ b/src/ui/mainmenu.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>95</height>
+    <width>500</width>
+    <height>113</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>300</width>
-    <height>95</height>
+    <width>500</width>
+    <height>113</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>300</width>
-    <height>95</height>
+    <width>500</width>
+    <height>113</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -43,8 +43,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>300</width>
-     <height>21</height>
+     <width>500</width>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_Game">


### PR DESCRIPTION
- Fixes an issue in MacOS 15.5 where the `QFileDialog::getExistingDirectory` doesn't open the file dialog and just immediately resolves to `dir.isNull()`
- Also widen the menu default size since its too small on my laptop and its wrapping the menu items:

Before:

<img width="392" alt="Screenshot 2025-07-04 at 8 07 55 PM" src="https://github.com/user-attachments/assets/0ad75951-5e88-4001-9454-073fc38b9030" />

After:

<img width="547" alt="Screenshot 2025-07-04 at 8 12 59 PM" src="https://github.com/user-attachments/assets/efae56ea-0665-4a5e-b364-24fb5edf0991" />
